### PR TITLE
Add missing esri module dependency

### DIFF
--- a/profiles/app.profile.js
+++ b/profiles/app.profile.js
@@ -80,7 +80,8 @@ var profile = {
         // probably in a nested require block or something the build script can't resolve
         'dojox/gfx/path',
         'dojox/gfx/svg',
-        'dojox/gfx/shape'
+        'dojox/gfx/shape',
+        'esri/dijit/Attribution'
       ]
     }//,
 


### PR DESCRIPTION
Looks like esri has a few dependencies for just using the esri/map module in Esri JSAPI 3.11. I noticed in the network traffic of the built app. that it was still looking for this module. Not sure if this was by design or not?